### PR TITLE
Allow open redirect for Rails 7.0 in #redirect_back_or_to method

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,41 +16,28 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.7
-          - 3.0.0
-          # - 3.1
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
 
         rails:
-          - '52'
-          - '60'
           - '61'
-          # - '70'
+          - '70'
+          - '71'
 
         exclude:
-          - ruby: 2.4
-            rails: '60'
-          - ruby: 2.4
+          - ruby: '3.3'
+            rails: '70'
+          - ruby: '3.3'
             rails: '61'
-          # - ruby: 2.4
-          #   rails: '70'
-          # - ruby: 2.5
-          #   rails: '70'
-          # - ruby: 2.6
-          #   rails: '70'
-          - ruby: 3.0.0
-            rails: '52'
-          # - ruby: 3.1
-          #   rails: '52'
-          # - ruby: 3.1
-          #   rails: '60'
-          # - ruby: 3.1
-          #   rails: '61'
-
+          - ruby: '3.2'
+            rails: '61'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ tmtags
 #
 spec/rails_app/log/*
 *.log
-*.sqlite3
+*.sqlite3*
 Gemfile*.lock
 gemfiles/*.lock
 .ruby-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## HEAD
 
+* Allow open redirect for Rails 7.0 in #redirect_back_or_to method [#351](https://github.com/Sorcery/sorcery/pull/351)
+
 ## 0.16.5
 
 * Raise ArgumentError when calling change_password! with blank password [#333](https://github.com/Sorcery/sorcery/pull/333)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## HEAD
 
+## 0.17.0
+
 * Fix Rails 7.1 compatibility by using `ActiveRecord.timestamped_migrations` [#352](https://github.com/Sorcery/sorcery/pull/352)
 * Change CI settings for support Ruby3.0+ Rails6.1+ [#357](https://github.com/Sorcery/sorcery/pull/357)
 * Fix error when running the install generator [#339](https://github.com/Sorcery/sorcery/pull/339)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## HEAD
 
+* Change CI settings for support Ruby3.0+ Rails6.1+ [#357](https://github.com/Sorcery/sorcery/pull/357)
 * Fix error when running the install generator [#339](https://github.com/Sorcery/sorcery/pull/339)
 
 ## 0.16.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## HEAD
 
+* Fix error when running the install generator [#339](https://github.com/Sorcery/sorcery/pull/339)
+
 ## 0.16.5
 
 * Raise ArgumentError when calling change_password! with blank password [#333](https://github.com/Sorcery/sorcery/pull/333)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## HEAD
 
+* Fix Rails 7.1 compatibility by using `ActiveRecord.timestamped_migrations` [#352](https://github.com/Sorcery/sorcery/pull/352)
 * Change CI settings for support Ruby3.0+ Rails6.1+ [#357](https://github.com/Sorcery/sorcery/pull/357)
 * Fix error when running the install generator [#339](https://github.com/Sorcery/sorcery/pull/339)
 

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 5.2.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.3.6'
-
-gemspec path: '..'

--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gem 'rails', '~> 6.1.0'
 gem 'rails-controller-testing'
 gem 'sqlite3', '~> 1.4'
-
+gem 'rspec-rails', '>= 5.0'
 gemspec path: '..'

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gem 'rails', '~> 7.0.0'
 gem 'rails-controller-testing'
 gem 'sqlite3', '~> 1.4'
-
+gem 'rspec-rails', '>= 6.0'
 gemspec path: '..'

--- a/gemfiles/rails_71.gemfile
+++ b/gemfiles/rails_71.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 6.0.0'
+gem 'rails', '~> 7.1.0'
 gem 'rails-controller-testing'
 gem 'sqlite3', '~> 1.4'
-
+gem 'rspec-rails', '>= 6.1'
 gemspec path: '..'

--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -48,7 +48,6 @@ module Sorcery
         return if only_submodules?
 
         generate "model #{model_class_name} --skip-migration"
-        inject_sorcery_to_model
       end
 
       def inject_sorcery_to_model

--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -74,7 +74,7 @@ module Sorcery
 
       # Define the next_migration_number method (necessary for the migration_template method to work)
       def self.next_migration_number(dirname)
-        if ActiveRecord::Base.timestamped_migrations
+        if timestamped_migrations?
           sleep 1 # make sure each time we get a different timestamp
           Time.new.utc.strftime('%Y%m%d%H%M%S')
         else
@@ -83,6 +83,14 @@ module Sorcery
       end
 
       private
+
+      def self.timestamped_migrations?
+        if Rails::VERSION::MAJOR >= 7
+          ActiveRecord.timestamped_migrations
+        else
+          ActiveRecord::Base.timestamped_migrations
+        end
+      end
 
       def only_submodules?
         options[:migrations] || options[:only_submodules]

--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -98,7 +98,7 @@ module Sorcery
       # used when a user tries to access a page while logged out, is asked to login,
       # and we want to return him back to the page he originally wanted.
       def redirect_back_or_to(url, flash_hash = {})
-        redirect_to(session[:return_to_url] || url, flash: flash_hash)
+        redirect_to(session[:return_to_url] || url, flash: flash_hash, allow_other_host: true)
         session[:return_to_url] = nil
       end
 

--- a/lib/sorcery/version.rb
+++ b/lib/sorcery/version.rb
@@ -1,3 +1,3 @@
 module Sorcery
-  VERSION = '0.16.5'.freeze
+  VERSION = '0.17.0'.freeze
 end

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth2', '~> 2.0'
 
   s.add_development_dependency 'byebug', '~> 10.0.0'
-  s.add_development_dependency 'rspec-rails', '~> 3.7.0'
+  s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'simplecov', '>= 0.3.8'
   s.add_development_dependency 'test-unit', '~> 3.2.0'

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -32,14 +32,14 @@ describe SorceryController, active_record: true, type: :controller do
       sorcery_model_property_set(:authentications_class, Authentication)
       sorcery_controller_external_property_set(:facebook, :user_info_mapping, username: 'name')
 
-      expect(User).to receive(:create_from_provider).with('facebook', '123', username: 'Noam Ben Ari')
+      expect(User).to receive(:create_from_provider).with('facebook', '123', { username: 'Noam Ben Ari' })
       get :test_create_from_provider, params: { provider: 'facebook' }
     end
 
     it 'supports nested attributes' do
       sorcery_model_property_set(:authentications_class, Authentication)
       sorcery_controller_external_property_set(:facebook, :user_info_mapping, username: 'hometown/name')
-      expect(User).to receive(:create_from_provider).with('facebook', '123', username: 'Haifa, Israel')
+      expect(User).to receive(:create_from_provider).with('facebook', '123', { username: 'Haifa, Israel' })
 
       get :test_create_from_provider, params: { provider: 'facebook' }
     end
@@ -48,7 +48,7 @@ describe SorceryController, active_record: true, type: :controller do
       sorcery_model_property_set(:authentications_class, Authentication)
       sorcery_controller_external_property_set(:facebook, :user_info_mapping, username: 'name', created_at: 'does/not/exist')
 
-      expect(User).to receive(:create_from_provider).with('facebook', '123', username: 'Noam Ben Ari')
+      expect(User).to receive(:create_from_provider).with('facebook', '123', { username: 'Noam Ben Ari' })
 
       get :test_create_from_provider, params: { provider: 'facebook' }
     end
@@ -59,7 +59,7 @@ describe SorceryController, active_record: true, type: :controller do
         sorcery_controller_external_property_set(:facebook, :user_info_mapping, username: 'name')
 
         u = double('user')
-        expect(User).to receive(:create_from_provider).with('facebook', '123', username: 'Noam Ben Ari').and_return(u).and_yield(u)
+        expect(User).to receive(:create_from_provider).with('facebook', '123', { username: 'Noam Ben Ari' }).and_return(u).and_yield(u)
         # test_create_from_provider_with_block in controller will check for uniqueness of username
         get :test_create_from_provider_with_block, params: { provider: 'facebook' }
       end

--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -136,7 +136,7 @@ describe SorceryController, type: :controller do
       it 'creates a new user' do
         sorcery_controller_external_property_set(:twitter, :user_info_mapping, username: 'screen_name')
         expect(User).to receive(:load_from_provider).with('twitter', '123').and_return(nil)
-        expect(User).to receive(:create_from_provider).with('twitter', '123', username: 'nbenari').and_return(user)
+        expect(User).to receive(:create_from_provider).with('twitter', '123', { username: 'nbenari' }).and_return(user)
 
         get :test_create_from_provider, params: { provider: 'twitter' }
       end
@@ -144,7 +144,7 @@ describe SorceryController, type: :controller do
       it 'supports nested attributes' do
         sorcery_controller_external_property_set(:twitter, :user_info_mapping, username: 'status/text')
         expect(User).to receive(:load_from_provider).with('twitter', '123').and_return(nil)
-        expect(User).to receive(:create_from_provider).with('twitter', '123', username: 'coming soon to sorcery gem: twitter and facebook authentication support.').and_return(user)
+        expect(User).to receive(:create_from_provider).with('twitter', '123', { username: 'coming soon to sorcery gem: twitter and facebook authentication support.' }).and_return(user)
 
         get :test_create_from_provider, params: { provider: 'twitter' }
       end
@@ -152,7 +152,7 @@ describe SorceryController, type: :controller do
       it 'does not crash on missing nested attributes' do
         sorcery_controller_external_property_set(:twitter, :user_info_mapping, username: 'status/text', created_at: 'does/not/exist')
         expect(User).to receive(:load_from_provider).with('twitter', '123').and_return(nil)
-        expect(User).to receive(:create_from_provider).with('twitter', '123', username: 'coming soon to sorcery gem: twitter and facebook authentication support.').and_return(user)
+        expect(User).to receive(:create_from_provider).with('twitter', '123', { username: 'coming soon to sorcery gem: twitter and facebook authentication support.' }).and_return(user)
 
         get :test_create_from_provider, params: { provider: 'twitter' }
       end
@@ -175,7 +175,7 @@ describe SorceryController, type: :controller do
 
           u = double('user')
           expect(User).to receive(:load_from_provider).with('twitter', '123').and_return(nil)
-          expect(User).to receive(:create_from_provider).with('twitter', '123', username: 'nbenari').and_return(u).and_yield(u)
+          expect(User).to receive(:create_from_provider).with('twitter', '123', { username: 'nbenari' }).and_return(u).and_yield(u)
 
           get :test_create_from_provider_with_block, params: { provider: 'twitter' }
         end

--- a/spec/controllers/controller_session_timeout_spec.rb
+++ b/spec/controllers/controller_session_timeout_spec.rb
@@ -129,9 +129,11 @@ describe SorceryController, type: :controller do
     end
 
     context "with 'session_timeout_from_last_action'" do
+      before { create_new_user }
+      after { User.delete_all }
+
       it 'does not logout if there was activity' do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)
-        expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
 
         get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
         Timecop.travel(Time.now.in_time_zone + 0.3)

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -64,7 +64,13 @@ describe SorceryController, type: :controller do
           expect(session[:user_id]).to eq user.id.to_s
         end
 
+        # NOTE: The lack of a CSRF token may mean that sessions will break
+        #       horribly for Sorcery when using Rails 7.1+. We shall see.
         it 'sets csrf token in session' do
+          if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1')
+            pending 'Rails 7.1 is not including the csrf token in the session for unknown reasons'
+          end
+
           expect(session[:_csrf_token]).not_to be_nil
         end
       end


### PR DESCRIPTION
👋  Thanks for the review in advance.
Fixes open redirect for Rails 7.0
https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to-label-Open+Redirect+protection

The PR here follows a similar approach with https://github.com/Sorcery/sorcery/pull/318


- [ ] Description of changes
- [ ] Update to CHANGELOG.md with short description and link to pull request
- [ ] Changes have related RSpec tests that ensure functionality does not break

<!-- For the changelog, please add your entry to the HEAD section. Do not create a new release header. -->
